### PR TITLE
Let llpp.inotify open filenames with spaces

### DIFF
--- a/misc/llpp.inotify
+++ b/misc/llpp.inotify
@@ -9,13 +9,13 @@ shift
 passthrough="$@"
 
 # Return with an error if the given file does not exist.
-if [ ! -e $pdf ]; then
+if [ ! -e "$pdf" ]; then
     echo "$pdf: No such file or directory"
     exit 1
 fi
 
 # Start llpp with the given file.
-llpp $pdf $passthrough &
+llpp "$pdf" $passthrough &
 
 # Track the PID of the llpp instance.
 pid_llpp=$!


### PR DESCRIPTION
Without this fix you get this:
```bash
$ llpp.inotify Pouet\ pouet.pdf
/usr/bin/llpp.inotify: line 12: [: Pouet: binary operator expected
error: cannot open pouet.pdf: No such file or directory
```